### PR TITLE
ci: use docker/login-action so cosign can authenticate to GHCR

### DIFF
--- a/.github/workflows/release-oci.yaml
+++ b/.github/workflows/release-oci.yaml
@@ -29,10 +29,15 @@ jobs:
         with:
           version: v4.2.0
 
+      # docker/login-action writes credentials to ~/.docker/config.json,
+      # which both helm (OCI client falls back to Docker config) and cosign
+      # read from. One login, one credential store for the whole job.
       - name: Log in to GHCR
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package and push
         id: publish


### PR DESCRIPTION
## Summary
- The publish workflow signs the pushed chart with cosign, which uploads the signature back to GHCR as a separate OCI artifact and therefore needs registry credentials.
- The prior `helm registry login` step writes only to helm's own credential store (`~/.config/helm/registry/config.json`); cosign reads `~/.docker/config.json`, so the signature upload failed with `UNAUTHORIZED: unauthenticated`.
- Replacing the manual login with `docker/login-action` writes to the Docker config — which helm's OCI client also falls back to — so one login now covers both `helm push` and `cosign sign`.

## Test plan
- [ ] Trigger the publish workflow (push to main touching `charts/spring-boot/**` or the workflow file) and confirm the `Sign and verify` step succeeds.
- [ ] Confirm `cosign verify ghcr.io/grafjo/charts/spring-boot:<x.y.z>` against the published artifact resolves successfully.